### PR TITLE
Correct doNotTrack property name

### DIFF
--- a/assets/js/tracker.js
+++ b/assets/js/tracker.js
@@ -34,7 +34,7 @@ function trackPageview() {
   }
 
   // Respect "Do Not Track" requests
-  if(navigator.DoNotTrack === "1") {
+  if('doNotTrack' in navigator && navigator.doNotTrack === "1") {
     return;
   }
 


### PR DESCRIPTION
It has to be lower camel case for it to work in browsers, and it’s the way its [defined in the spec](https://www.w3.org/TR/tracking-dnt/#x5-3-javascript-property-to-detect-preference).