### PR TITLE
Fix missing script id attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To start tracking, include the following JavaScript on your site and replace `yo
 	};
 	o=f.createElement('script'),
 	m=f.getElementsByTagName('script')[0];
-	o.async=1; o.src=t;
+	o.async=1; o.src=t; o.id='fathom-script';
 	m.parentNode.insertBefore(o,m)
 })(document, window, '//yourfathom.com/tracker.js', 'fathom');
 fathom('trackPageview');


### PR DESCRIPTION
When `setTrackerUrl` method is not called before `trackPageView`, the tracker will [try to find its location](https://github.com/lovethebomb/fathom/blob/master/assets/js/tracker.js#L46-L49) based on the script element with id attribute of `fathom-script`. 

This id attribute was missing in the README snippet.