### PR TITLE
Add working Docker build and run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:latest AS compiler
 WORKDIR /go/src/github.com/usefathom/fathom
 ADD . /go/src/github.com/usefathom/fathom
-RUN go get -u github.com/gobuffalo/packr/... && make build
+RUN go get -u github.com/gobuffalo/packr/... && make docker
 
 FROM alpine:latest
 EXPOSE 8080
+RUN apk add --update --no-cache bash ca-certificates
 WORKDIR /app
 COPY --from=compiler /go/src/github.com/usefathom/fathom/fathom .
 CMD ["./fathom", "server"]
-RUN apk add --update bash ca-certificates && rm -rf /var/cache/apk/*

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ install: $(wildcard *.go) $(GOPATH)/bin/packr
 .PHONY: build
 build: $(EXECUTABLE)
 
+.PHONY: docker
+docker: $(GO_SOURCES) assets/build
+	GOOS=linux GOARCH=amd64 $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $(EXECUTABLE) $(MAIN_PKG)
+
 $(EXECUTABLE): $(GO_SOURCES) assets/build
 	go build -o $@ $(MAIN_PKG)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ For getting a development version of Fathom up & running, go through the followi
 
 To install and run Fathom in production, [have a look at the installation instructions](https://github.com/usefathom/fathom/wiki/Installing-&-running-Fathom).
 
+## Building with Docker
+
+Ensure you have Docker installed and run `docker build -t fathom .`.
+Run the container with `docker run -d -p 8080:8080 fathom`.
+
 #### Tracking snippet 
 
 To start tracking, include the following JavaScript on your site and replace `yourfathom.com` with the URL to your Fathom instance.


### PR DESCRIPTION
I think it would be nice to have an "official automated build for fathom". First step is to get a working Dockerfile and run phase. This commit make it work. (The make build and then copying the bin to alpine was not working). 

What do you think of creating an automated build for fathom?

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>