### PR TITLE
Don’t send Referer headers

### DIFF
--- a/assets/src/index.html
+++ b/assets/src/index.html
@@ -4,6 +4,7 @@
   <title>Fathom - simple website analytics</title>
   <link href="/assets/css/styles.css" rel="stylesheet">
   <meta charset="utf-8">
+  <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon.png">
 </head>


### PR DESCRIPTION
Remove the `Referer` request header when clicking on referrer links in Fathom. This isn’t a public page so keep the secret of its existence.
https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer