### PR TITLE
Extend search engines to cover top #5 worldwide

### DIFF
--- a/pkg/aggregator/store.go
+++ b/pkg/aggregator/store.go
@@ -90,6 +90,21 @@ func (agg *aggregator) getReferrerStats(r *results, t time.Time, hostname string
 		if strings.Contains(stats.Hostname, "www.google.") {
 			stats.Group = "Google"
 		}
+		elseif strings.Contains(stats.Hostname, "www.bing.") {
+			stats.Group = "Bing"
+		}
+		elseif strings.Contains(stats.Hostname, "www.baidu.") {
+			stats.Group = "Baidu"
+		}
+		elseif strings.Contains(stats.Hostname, "www.yandex.") {
+			stats.Group = "Yandex"
+		}
+		elseif strings.Contains(stats.Hostname, "search.yahoo.") {
+			stats.Group = "Yahoo!"
+		}
+		elseif strings.Contains(stats.Hostname, "www.findx.") {
+			stats.Group = "Findx"
+		}
 
 		err = agg.database.InsertReferrerStats(stats)
 		if err != nil {


### PR DESCRIPTION
Challenging the Google monopoly by recognizing Bing, Baidu, Yandex, and Yahoo!

Findx gets honorary inclusion because they operate an independent search index. (Yandex, DuckDuckGo, and Ecosia gets search results from Bing; StartPage, DogPile, and AOL gets theirs from Google.)