### PR TITLE
Update Makefile and Dockerfile for non-amd64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,37 @@
-FROM node:alpine AS assetbuilder
+ARG ASSETDIST=node:alpine
+ARG GODIST=golang:latest
+ARG GOARCH=amd64
+ARG RELEASEDIST=alpine:latest
+
+FROM $ASSETDIST AS assetbuilder
+RUN apk --no-cache add git python build-base
 WORKDIR /app
 COPY package*.json ./
 COPY gulpfile.js ./
 COPY assets/ ./assets/
 RUN npm install && NODE_ENV=production npx gulp
 
-FROM golang:latest AS binarybuilder
+# Need to persist the build args across build stages
+#    By default they are being consumed by the first build step for some reason
+#    See docker docs : https://docs.docker.com/engine/reference/builder/#scope
+#    "An ARG instruction goes out of scope at the end of the build stage where it was defined. To use
+ARG GODIST
+ARG GOARCH
+ARG RELEASEDIST
+
+FROM $GODIST AS binarybuilder
 WORKDIR /go/src/github.com/usefathom/fathom
 COPY . /go/src/github.com/usefathom/fathom
 COPY --from=assetbuilder /app/assets/build ./assets/build
-RUN go get -u github.com/gobuffalo/packr/... && make docker
+RUN go get -u github.com/gobuffalo/packr/... && make ARCH=${GOARCH} docker
 
-FROM alpine:latest
+# Persist build arg (see above for details)
+ARG RELEASEDIST
+
+FROM ${RELEASEDIST}
 EXPOSE 8080
-RUN apk add --update --no-cache bash ca-certificates
+RUN apk add --update --no-cache bash ca-certificates sqlite libpq postgresql-client mysql-client
 WORKDIR /app
 COPY --from=binarybuilder /go/src/github.com/usefathom/fathom/fathom .
 CMD ["./fathom", "server"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+ARCH := amd64
 DIST := build
 EXECUTABLE := fathom
 LDFLAGS += -extldflags "-static"
@@ -21,15 +22,15 @@ build: $(EXECUTABLE)
 
 .PHONY: docker
 docker: $(GO_SOURCES) 
-	GOOS=linux GOARCH=amd64 $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $(EXECUTABLE) $(MAIN_PKG)
+	GOOS=linux GOARCH=$(ARCH) $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $(EXECUTABLE) $(MAIN_PKG)
 
 $(EXECUTABLE): $(GO_SOURCES) assets/build
 	go build -o $@ $(MAIN_PKG)
 
-dist: assets/dist build/fathom-linux-amd64
+dist: assets/dist build/fathom-linux-$(ARCH)
 
-build/fathom-linux-amd64: $(GOPATH)/bin/packr $(SQL_SOURCES) $(GO_SOURCES) $(JS_SOURCES)
-	GOOS=linux GOARCH=amd64 $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $@ $(MAIN_PKG)
+build/fathom-linux-$(ARCH): $(GOPATH)/bin/packr $(SQL_SOURCES) $(GO_SOURCES) $(JS_SOURCES)
+	GOOS=linux GOARCH=$(ARCH) $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $@ $(MAIN_PKG)
 
 $(GOPATH)/bin/packr:
 	GOBIN=$(GOPATH)/bin go get github.com/gobuffalo/packr/...

--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -100,7 +100,6 @@ function trackPageview() {
     sid: data.sid,
     p: path,
     h: hostname,
-    t: document.title,
     r: referrer,
     u: data.pagesViewed.indexOf(path) == -1 ? 1 : 0,
     nv: data.isNewVisitor ? 1 : 0, 

--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -68,16 +68,21 @@ function trackPageview() {
     return;
   }
 
-  // get the path or canonical
-  let path = location.pathname + location.search;
+  let req = window.location;
 
-  // parse path from canonical, if page has one
+  // parse canonical, if page has one
   let canonical = document.querySelector('link[rel="canonical"][href]');
   if(canonical) {
     let a = document.createElement('a');
     a.href = canonical.href;
-    path = a.pathname;
+
+    // use parsed canonical as location object
+    req = a;
   }
+
+  // get path and pathname from location or canonical
+  let path = req.pathname + req.search;
+  let hostname = req.protocol + "//" + req.hostname;
 
   // if parsing path failed, default to main page
   if(!path) {
@@ -94,6 +99,7 @@ function trackPageview() {
   const d = {
     sid: data.sid,
     p: path,
+    h: hostname,
     t: document.title,
     r: referrer,
     u: data.pagesViewed.indexOf(path) == -1 ? 1 : 0,

--- a/pkg/api/collect.go
+++ b/pkg/api/collect.go
@@ -25,10 +25,6 @@ func shouldCollect(r *http.Request) bool {
 		return false
 	}
 
-	if r.Referer() == "" {
-		return false
-	}
-
 	return true
 }
 
@@ -79,15 +75,10 @@ func (api *API) NewCollectHandler() http.Handler {
 		q := r.URL.Query()
 		now := time.Now()
 
-		hostname := parseHostname(r.Referer())
-		if hostname == "" {
-			return nil
-		}
-
 		// get pageview details
 		pageview := &models.Pageview{
 			SessionID:    q.Get("sid"),
-			Hostname:     hostname,
+			Hostname:     parseHostname(q.Get("h")),
 			Pathname:     parsePathname(q.Get("p")),
 			IsNewVisitor: q.Get("nv") == "1",
 			IsNewSession: q.Get("ns") == "1",


### PR DESCRIPTION
Allow building Fathom for non-amd64 architectures by adding variables to the Dockerfile as well as Makefile.

The Makefile has been updated to have "ARCH" as a build variable that defaults to amd64 (current arch).

The Dockerfile has been updated for more granular control over the go build arch as well as which images are used for asset builds, go builds and final image creation.

Dockerfile was also updated to include pgsql/mysql/sqlite clients inside the final container to help end-users troubleshoot any database connection issues that may arise.

Example build invocation for arm64v8 architecture (tested working):
```
docker build \
    --file ./Dockerfile \
    --build-arg ASSETDIST=arm64v8/node:alpine \
    --build-arg GODIST=arm64v8/golang:alpine \
    --build-arg RELEASEDIST=arm64v8/alpine:latest \
    --build-arg GOARCH=${GOARCH} \
    --tag arm64v8/fathom:latest \
    .
```