### PR TITLE
link[href] is already an absolute URL

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -73,11 +73,7 @@ function trackPageview() {
   // parse canonical, if page has one
   let canonical = document.querySelector('link[rel="canonical"][href]');
   if(canonical) {
-    let a = document.createElement('a');
-    a.href = canonical.href;
-
-    // use parsed canonical as location object
-    req = a;
+    req = canonical.href;
   }
 
   // get path and pathname from location or canonical


### PR DESCRIPTION
a[href] and link[href] will both normalize to an absolute URL so there is no need to create an extra a element here. Additionally, Google decrees that authors should only include absolute URLs in their document. So both browsers and Google are working for us here.