### PR TITLE
Revert "link[href] is already an absolute URL"

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -73,7 +73,11 @@ function trackPageview() {
   // parse canonical, if page has one
   let canonical = document.querySelector('link[rel="canonical"][href]');
   if(canonical) {
-    req = canonical.href;
+    let a = document.createElement('a');
+    a.href = canonical.href;
+
+    // use parsed canonical as location object
+    req = a;
   }
 
   // get path and pathname from location or canonical


### PR DESCRIPTION
Reverts usefathom/fathom#98, because #101 