### PR TITLE
Adding /health endpoint and using it in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go get -u github.com/gobuffalo/packr/... && make docker
 
 FROM alpine:latest
 EXPOSE 8080
+HEALTHCHECK --retries=10 CMD ["wget", "-qO-", "http://localhost:8080/health"]
 RUN apk add --update --no-cache bash ca-certificates
 WORKDIR /app
 COPY --from=binarybuilder /go/src/github.com/usefathom/fathom/fathom .

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -1,0 +1,14 @@
+package api
+
+import "net/http"
+
+// GET /health
+func (api *API) Health(w http.ResponseWriter, _ *http.Request) error {
+	if err := api.database.Health(); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return err
+	}
+
+	w.WriteHeader(http.StatusOK)
+	return nil
+}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -30,6 +30,8 @@ func (api *API) Routes() *mux.Router {
 	r.Handle("/api/stats/referrers", api.Authorize(HandlerFunc(api.GetReferrerStatsHandler))).Methods(http.MethodGet)
 	r.Handle("/api/stats/referrers/pageviews", api.Authorize(HandlerFunc(api.GetReferrerStatsPageviewsHandler))).Methods(http.MethodGet)
 
+	r.Handle("/health", HandlerFunc(api.Health)).Methods(http.MethodGet)
+
 	// static assets & 404 handler
 	box := packr.NewBox("./../../assets/build")
 	r.Path("/tracker.js").Handler(serveTrackerFile(&box))

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -53,6 +53,7 @@ type Datastore interface {
 	GetAggregatedReferrerStatsPageviews(time.Time, time.Time) (int, error)
 
 	// misc
+	Health() error
 	Close() error
 }
 

--- a/pkg/datastore/sqlstore/sqlstore.go
+++ b/pkg/datastore/sqlstore/sqlstore.go
@@ -1,7 +1,9 @@
 package sqlstore
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql" // mysql driver
 	"github.com/gobuffalo/packr"
@@ -62,6 +64,14 @@ func (db *sqlstore) Migrate() {
 	if n > 0 {
 		log.Infof("Applied %d database migrations!", n)
 	}
+}
+
+// Health check health of database
+func (db *sqlstore) Health() error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	return db.PingContext(ctx)
 }
 
 // Closes the db pool


### PR DESCRIPTION
I've added a `/health` endpoint that check database connectivity for easier status monitoring of server.

I've also added it to the Dockerfile for being displayed directly by Docker

```bash
IMAGE                            STATUS                
fathom                           Up 2 minutes (healthy)
```