### PR TITLE
add listener for history.pushState to detect SPA navigation

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -172,20 +172,20 @@ function trackPageview() {
 }
 
 // add listener for history.pushState to detect SPA navigation
-var h = window.history
+var h = window.history;
 if (h && h.pushState && Event && window.dispatchEvent) {
   var stateListener = function(type) {
-    var orig = h[type]
+    var orig = h[type];
     return function() {
-      var rv = orig.apply(this, arguments)
-      var event = new Event(type)
-      event.arguments = arguments
-      window.dispatchEvent(event)
-      return rv
+      var rv = orig.apply(this, arguments);
+      var event = new Event(type);
+      event.arguments = arguments;
+      window.dispatchEvent(event);
+      return rv;
     }
   }
-  h.pushState = stateListener('pushState')
-  window.addEventListener('pushState', trackPageview)
+  h.pushState = stateListener('pushState');
+  window.addEventListener('pushState', trackPageview);
 }
 
 // override global fathom object

--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -171,6 +171,23 @@ function trackPageview() {
   window.setTimeout(() => { document.body.removeChild(i)}, 1000);
 }
 
+// add listener for history.pushState to detect SPA navigation
+var his = window.history
+if (his && his.pushState && Event && window.dispatchEvent) {
+  var stateListener = function(type) {
+    var orig = his[type]
+    return function() {
+      var rv = orig.apply(this, arguments)
+      var event = new Event(type)
+      event.arguments = arguments
+      window.dispatchEvent(event)
+      return rv
+    }
+  }
+  his.pushState = stateListener('pushState')
+  window.addEventListener('pushState', trackPageview)
+}
+
 // override global fathom object
 window.fathom = function() {
   var args = [].slice.call(arguments);

--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -172,10 +172,10 @@ function trackPageview() {
 }
 
 // add listener for history.pushState to detect SPA navigation
-var his = window.history
-if (his && his.pushState && Event && window.dispatchEvent) {
+var h = window.history
+if (h && h.pushState && Event && window.dispatchEvent) {
   var stateListener = function(type) {
-    var orig = his[type]
+    var orig = h[type]
     return function() {
       var rv = orig.apply(this, arguments)
       var event = new Event(type)
@@ -184,7 +184,7 @@ if (his && his.pushState && Event && window.dispatchEvent) {
       return rv
     }
   }
-  his.pushState = stateListener('pushState')
+  h.pushState = stateListener('pushState')
   window.addEventListener('pushState', trackPageview)
 }
 


### PR DESCRIPTION
At the moment Fathom can't tell if the there was a url change in a SPA, because it only creates a tracking image when a page was loaded. According to my understanding this is done via `trackPageview()`. In this pull request i propose listening on the `window.history.pushState` event to detect if an url has changed and fire `trackPageview()` again. This would have the advantage, that react, vue, angular, etc. applications can be tracked correctly instead of just tracking the initial page load.

I really would like to see this feature in the future. If something is wrong with my PR (it's my first one ever), please let me know.