### PR TITLE
remove tracking image after it finished loading

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -172,8 +172,8 @@ function trackPageview() {
     data.lastSeen = +new Date();
     setCookie('_fathom', JSON.stringify(data), { expires: midnight, path: '/' });
   });
+  i.addEventListener('load', () => document.body.removeChild(i));
   document.body.appendChild(i);
-  window.setTimeout(() => { document.body.removeChild(i)}, 1000);
 }
 
 // override global fathom object


### PR DESCRIPTION
removes the tracking image immediately after it was loaded instead of the current 1000ms estimate