### PR TITLE
fix navigation with arrow keys

### DIFF
--- a/assets/src/js/components/DatePicker.js
+++ b/assets/src/js/components/DatePicker.js
@@ -178,7 +178,7 @@ class DatePicker extends Component {
     let diff = this.state.endDate - this.state.startDate + 1000;
     let newStartDate, newEndDate;
 
-    switch(evt.keyCode) {
+    switch(evt.which) {
       // left-arrow
       case 37:
         newStartDate = new Date(+this.state.startDate - diff)

--- a/assets/src/js/components/DatePicker.js
+++ b/assets/src/js/components/DatePicker.js
@@ -169,7 +169,7 @@ class DatePicker extends Component {
   @bind
   handleKeyPress(evt) {
     // Don't handle input when the user is in a text field or text area.
-    let tag = event.target.tagName;
+    let tag = evt.target.tagName;
     if(tag === "INPUT" || tag === "TEXTAREA") {
       return;
     }

--- a/assets/src/js/components/SiteSettings.js
+++ b/assets/src/js/components/SiteSettings.js
@@ -89,7 +89,7 @@ class SiteSettings extends Component {
     @bind 
     handleKeydownEvent(evt) {
         // close modal when pressing ESC 
-        if(evt.keyCode == 27) {
+        if(evt.which == 27) {
             this.props.onClose()
         }
     }


### PR DESCRIPTION
This PR fixes the date range navigation using the arrow keys (the wrong variable name was used). It also replaces the deprecated `KeyboardEvent.keyCode` with `KeyboardEvent.which` (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)).