### PR TITLE
Improve Accessibility of tracker.js

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -166,6 +166,8 @@
 
     let url = config.trackerUrl || findTrackerUrl()
     let img = document.createElement('img');
+    img.setAttribute('alt', '');
+    img.setAttribute('aria-hidden', 'true');
     img.src = url + stringifyObject(d);
     img.addEventListener('load', function() {
       let now = new Date();


### PR DESCRIPTION
fathom is creating an image element for tracking which is not accessibility compliant.

This severely lowers my https://web.dev/measure score.

<img width="1666" alt="screenshot 2018-11-16 at 15 32 50 redacted" src="https://user-images.githubusercontent.com/6954968/48627592-3c034600-e9b5-11e8-807f-4d3c1f301db5.png">

This PR is adding an empty `alt` tag and the `aria-hidden` tag to indicate irrelevance of the image to screenreaders.

> To tell assistive technology to ignore an image, use a "blank alternative text" attribute: alt="".
https://dequeuniversity.com/rules/axe/2.2/image-alt?application=lighthouse
