### PR TITLE
Non amd64 support / packr fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY assets/ ./assets/
 RUN npm install && NODE_ENV=production ./node_modules/gulp/bin/gulp.js
 
 FROM golang:latest AS binarybuilder
+RUN go get -u github.com/gobuffalo/packr/packr
 WORKDIR /go/src/github.com/usefathom/fathom
 COPY . /go/src/github.com/usefathom/fathom
 COPY --from=assetbuilder /app/assets/build ./assets/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ FROM golang:latest AS binarybuilder
 WORKDIR /go/src/github.com/usefathom/fathom
 COPY . /go/src/github.com/usefathom/fathom
 COPY --from=assetbuilder /app/assets/build ./assets/build
-RUN make docker
+ARG GOARCH=amd64
+RUN make ARCH=${GOARCH} docker
 
 FROM alpine:latest
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 ASSET_SOURCES ?= $(shell find assets/src/. -type f)
 GO_SOURCES ?= $(shell find . -name "*.go" -type f)
 GOPATH=$(shell go env GOPATH)
+ARCH := amd64
 
 .PHONY: all
 all: build 
@@ -17,7 +18,7 @@ $(EXECUTABLE): $(GO_SOURCES) assets/build
 
 .PHONY: docker
 docker: $(GO_SOURCES) 
-	GOOS=linux GOARCH=amd64 $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $(EXECUTABLE) $(MAIN_PKG)
+	GOOS=linux GOARCH=$(ARCH) $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $(EXECUTABLE) $(MAIN_PKG)
 
 $(GOPATH)/bin/packr:
 	GOBIN=$(GOPATH)/bin go get -u github.com/gobuffalo/packr/packr


### PR DESCRIPTION
This PR will update the make file and docker file to allow non-amd64 arch's to be passed through the build engine. This will allow arm and arm64 support to be built natively.

This will also add packr to the docker build steps which is missing on some platforms.