### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN make docker
 
 FROM alpine:latest
 EXPOSE 8080
-HEALTHCHECK --retries=10 CMD ["wget", "-qO-", "http://localhost:8080/health"]
 RUN apk add --update --no-cache bash ca-certificates
 WORKDIR /app
 COPY --from=binarybuilder /go/src/github.com/usefathom/fathom/fathom .


### PR DESCRIPTION
My Fathom service has always the status "unhealthy" although it's running.

I guess it's because alpine:latest does not have `curl` as dependency. So, the check does not work at all.