### PR TITLE
Update Running Fathom with NGINX doc 

### DIFF
--- a/docs/misc/NGINX.md
+++ b/docs/misc/NGINX.md
@@ -19,7 +19,13 @@ server {
 }
 ```
 
-If you wish to protect your site using a [Let's Encrypt](https://letsencrypt.org/) HTTPS certificate, you can do so using the [Certbot webroot plugin](https://certbot.eff.org/docs/using.html#webroot). Your `/etc/nginx/sites-enabled/yourfathom.com` file should be updated accordingly:
+If you wish to protect your site using a [Let's Encrypt](https://letsencrypt.org/) HTTPS certificate, you can do so using the [Certbot webroot plugin](https://certbot.eff.org/docs/using.html#webroot). 
+
+```
+certbot certonly --webroot --webroot-path /var/www/yourfathom.com -d yourfathom.com
+```
+
+Your `/etc/nginx/sites-enabled/yourfathom.com` file should be updated accordingly:
 
 ```
 server {
@@ -45,10 +51,6 @@ server {
 ```
 
 The `alias` directive should point to the location where your `--webroot-path` is specified when generating the certificate (with `/.well-known` appended).
-
-```
-certbot certonly --webroot --webroot-path /var/www/yourfathom.com -d yourfathom.com
-```
 
 ### Test NGINX configuration
 ```

--- a/docs/misc/NGINX.md
+++ b/docs/misc/NGINX.md
@@ -19,6 +19,37 @@ server {
 }
 ```
 
+If you wish to protect your site using a [Let's Encrypt](https://letsencrypt.org/) HTTPS certificate, you can do so using the [Certbot webroot plugin](https://certbot.eff.org/docs/using.html#webroot). Your `/etc/nginx/sites-enabled/yourfathom.com` file should be updated accordingly:
+
+```
+server {
+	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
+
+	server_name yourfathom.com;
+
+	ssl_certificate /path/to/your/fullchain.pem;
+	ssl_certificate_key /path/to/your/privkey.pem;
+
+	location /.well-known {
+		alias /var/www/yourfathom.com/.well-known;
+	}
+
+	location / {
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_set_header Host $host;
+		proxy_pass http://127.0.0.1:9000; 
+	}
+}
+```
+
+The `alias` directive should point to the location where your `--webroot-path` is specified when generating the certificate (with `/.well-known` appended).
+
+```
+certbot certonly --webroot --webroot-path /var/www/yourfathom.com -d yourfathom.com
+```
+
 ### Test NGINX configuration
 ```
 sudo nginx -t


### PR DESCRIPTION
This adds instructions on how to configure Let's Encrypt when proxying Fathom through Nginx.