### PR TITLE
Remove redundant nil check

### DIFF
--- a/pkg/cli/stats.go
+++ b/pkg/cli/stats.go
@@ -53,8 +53,7 @@ func stats(c *cli.Context) error {
 	}
 
 	if c.Bool("json") {
-		err := json.NewEncoder(os.Stdout).Encode(result)
-		return err
+		return json.NewEncoder(os.Stdout).Encode(result)
 	}
 
 	fmt.Printf("%s - %s\n", start.Format("Jan 01, 2006"), end.Format("Jan 01, 2006"))

--- a/pkg/cli/stats.go
+++ b/pkg/cli/stats.go
@@ -53,11 +53,8 @@ func stats(c *cli.Context) error {
 	}
 
 	if c.Bool("json") {
-		if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
-			return err
-		}
-
-		return nil
+		err := json.NewEncoder(os.Stdout).Encode(result)
+		return err
 	}
 
 	fmt.Printf("%s - %s\n", start.Format("Jan 01, 2006"), end.Format("Jan 01, 2006"))


### PR DESCRIPTION
The lack of a JSON encode error will produce & return `nil` regardless. Hopefully this helps!