### PR TITLE
fix Heroku env var instructions

### DIFF
--- a/docs/misc/Heroku.md
+++ b/docs/misc/Heroku.md
@@ -64,7 +64,7 @@ heroku config:set PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/
   FATHOM_DATABASE_DRIVER=postgres \
   FATHOM_DATABASE_URL=$(heroku config:get DATABASE_URL) \
   FATHOM_DEBUG=true \
-  FATHOM_SECRET= $(openssl rand -base64 32) \
+  FATHOM_SECRET=$(openssl rand -base64 32) \
   FATHOM_GZIP=true
 ```
 


### PR DESCRIPTION
The extra _space_ character between `FATHOM_SECRET` and `$(openssl …)` broke the command because it set `FATHOM SECRET` to `''` and interpreted the generated secret as the name of the next env var to set. 

```shell
$ heroku config:set PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/bin \
  FATHOM_DATABASE_DRIVER=postgres \
  FATHOM_DATABASE_URL=$(heroku config:get DATABASE_URL) \
  FATHOM_DEBUG=true \
  FATHOM_SECRET= $(openssl rand -base64 32) \
  FATHOM_GZIP=true
Setting PATH, FATHOM_DATABASE_DRIVER, FATHOM_DATABASE_URL, FATHOM_DEBUG, FATHOM_SECRET, 0ACl9FJMKgllHAXZUUqmm7PQ3P92MuQlN6lt/5OLdkg, FATHOM_GZIP and restarting ⬢ my-app-name... !
 ▸    Name is invalid
```

(I'm not using the secret from this snippet anywhere)