### PR TITLE
Change tracker.js Cache-Control header to no-store

### DIFF
--- a/pkg/api/collect.go
+++ b/pkg/api/collect.go
@@ -75,7 +75,7 @@ func (c *Collector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// headers to prevent caching
 	w.Header().Set("Content-Type", "image/gif")
 	w.Header().Set("Expires", "Mon, 01 Jan 1990 00:00:00 GMT")
-	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
 
 	// response, 1x1 px transparent GIF


### PR DESCRIPTION
According to all documentation I can find, `no-store` is the strongest "do not cache" `Cache-Control` header there is, and `no-cache` and `must-revalidate` are strictly weaker and will have no effect when `no-store` is present. Additionally, I cannot find any evidence that these other values are useful for backwards compatibility or older browsers, and `no-store` support appears to be universal. Lastly, webhint.io is specifically telling me that I should not use `must-revalidate`.