### PR TITLE
Makes sure fetch param are integers

### DIFF
--- a/assets/src/js/components/Chart.js
+++ b/assets/src/js/components/Chart.js
@@ -275,8 +275,8 @@ class Chart extends Component {
   fetchData(props) {
     this.setState({ loading: true })
 
-    let before = props.dateRange[1]/1000;
-    let after = props.dateRange[0]/1000;
+    let before = Math.round(props.dateRange[1]/1000);
+    let after = Math.round(props.dateRange[0]/1000);
 
     Client.request(`/sites/${props.siteId}/stats/site?before=${before}&after=${after}`)
       .then(data => { 

--- a/assets/src/js/components/Sidebar.js
+++ b/assets/src/js/components/Sidebar.js
@@ -31,8 +31,8 @@ class Sidebar extends Component {
   @bind
   fetchData(props) {
     this.setState({ loading: true })
-    let before = props.dateRange[1]/1000;
-    let after = props.dateRange[0]/1000;
+    let before = Math.round(props.dateRange[1]/1000);
+    let after = Math.round(props.dateRange[0]/1000);
 
     Client.request(`/sites/${props.siteId}/stats/site/agg?before=${before}&after=${after}`)
       .then((data) => { 

--- a/assets/src/js/components/Table.js
+++ b/assets/src/js/components/Table.js
@@ -38,8 +38,8 @@ class Table extends Component {
   @bind
   fetchData(props) {
     this.setState({ loading: true });
-    let before = props.dateRange[1]/1000;
-    let after = props.dateRange[0]/1000;
+    let before = Math.round(props.dateRange[1]/1000);
+    let after = Math.round(props.dateRange[0]/1000);
 
     Client.request(`/sites/${props.siteId}/stats/${props.endpoint}/agg?before=${before}&after=${after}&offset=${this.state.offset}&limit=${this.state.limit}`)
       .then((d) => {


### PR DESCRIPTION
# Context, issue #267 
Reported by @RealOrangeOne 
> Selecting 'YTD' shows all the stats i'd expect it to, but 'ALL' shows 0's all around.
> Requests to the /agg endpoint return all 0s.

# What's hapenning ?

In the date picker, the 'all' sets the end date range using "new Date()" which is rarely divisible by 1000.

https://github.com/usefathom/fathom/blob/d6f207d1bc83e398fc1939156be67734035dbf23/assets/src/js/components/DatePicker.js#L74-L81

And a typical data fetch divides the range by 1000 to convert it in seconds:
https://github.com/usefathom/fathom/blob/d62c9b9f812ec77dbc6562b4431f481fab96d8db/assets/src/js/components/Table.js#L39-L44

But for - as @RealOrangeOne pointed out -, for the 'all' case this causes 'before' to have a decimal part, but the server is expecting an integer: 
https://github.com/usefathom/fathom/blob/eb2eb726f3ab977c55c526b72afda2f2687b9948/pkg/api/params.go#L44-L48

# Alternative way to fix this: 

1. To fix this, you could also make sure that the date ranges are always divisible by 1000. 
2. Or you could fix the server to parse floating point number. 

PS: I have not tested the fix. 