### PR TITLE
add SameSite and Secure attribute to cookie

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -64,7 +64,7 @@
       str += ';expires='+args.expires.toUTCString();
     }
 
-    document.cookie = str;
+    document.cookie = str + ';SameSite=None;Secure';
   }
 
   function newVisitorData() {


### PR DESCRIPTION
I noticed the following warning message in devtools after self-hosting fathom-lite:

> A cookie associated with a cross-site resource at [my-url] was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.

Here's an in-depth article explaining the purpose of the `SameSite` attribute: https://blog.heroku.com/chrome-changes-samesite-cookie.

I referred to this [github example](https://github.com/GoogleChromeLabs/samesite-examples/blob/master/javascript.md) to add the SameSite and Secure attribute.