### PR TITLE
Allow Tracking From Electron Applications

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -129,8 +129,8 @@
     //  parse request, use canonical if there is one
     let req = window.location;
 
-    // do not track if not served over HTTP or HTTPS (eg from local filesystem)
-    if(req.host === '') {
+    // do not track if not served over HTTP or HTTPS (eg from local filesystem) and we're not in an Electron app
+    if(req.host === '' && navigator.userAgent.indexOf("Electron") < 0) {
       return;
     }
 


### PR DESCRIPTION
In Electron the application can be served from the file system, meaning tracking is impossible with the original check in place.

Electron apps have a user agent like
```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) {{app_name}}/{{app_version}} Chrome/83.0.4103.122 Electron/9.4.4 Safari/537.36
```

so we can check if it contains `Electron` and continue if it it does.