### PR TITLE
go: Fix build; move to modern go install cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY assets/ ./assets/
 RUN npm install && NODE_ENV=production ./node_modules/gulp/bin/gulp.js
 
 FROM golang:latest AS binarybuilder
-RUN go get -u github.com/gobuffalo/packr/packr
+RUN go install github.com/gobuffalo/packr/packr@latest
 WORKDIR /go/src/github.com/usefathom/fathom
 COPY . /go/src/github.com/usefathom/fathom
 COPY --from=assetbuilder /app/assets/build ./assets/build

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ $(EXECUTABLE): $(GO_SOURCES) assets/build
 	go build -o $@ $(MAIN_PKG)
 
 .PHONY: docker
-docker: $(GO_SOURCES) 
+docker: $(GO_SOURCES) $(GOPATH)/bin/packr
 	GOOS=linux GOARCH=amd64 $(GOPATH)/bin/packr build -v -ldflags '-w $(LDFLAGS)' -o $(EXECUTABLE) $(MAIN_PKG)
 
 $(GOPATH)/bin/packr:
-	GOBIN=$(GOPATH)/bin go get -u github.com/gobuffalo/packr/packr
+	GOBIN=$(GOPATH)/bin go install github.com/gobuffalo/packr/packr@latest
 
 .PHONY: npm 
 npm:
@@ -35,7 +35,7 @@ assets/dist: $(ASSET_SOURCES) npm
 .PHONY: clean
 clean:
 	go clean -i ./...
-	packr clean
+	$(GOPATH)/bin/packr clean
 	rm -rf $(EXECUTABLE)
 
 .PHONY: fmt
@@ -49,14 +49,14 @@ vet:
 .PHONY: errcheck
 errcheck:
 	@which errcheck > /dev/null; if [ $$? -ne 0 ]; then \
-		go get -u github.com/kisielk/errcheck; \
+		go install github.com/kisielk/errcheck@latest; \
 	fi
 	errcheck $(PACKAGES)
 
 .PHONY: lint
 lint:
 	@which golint > /dev/null; if [ $$? -ne 0 ]; then \
-		go get -u github.com/golang/lint/golint; \
+		go install github.com/golang/lint/golint@latest; \
 	fi
 	for PKG in $(PACKAGES); do golint -set_exit_status $$PKG || exit 1; done;
 

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,13 @@ require (
 
 require (
 	github.com/gorilla/securecookie v1.1.2-0.20180608144417-78f3d318a8bf // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1-0.20180311214515-816c9085562c // indirect
+	github.com/spf13/cobra v0.0.3 // indirect
+	github.com/spf13/pflag v1.0.2 // indirect
 	github.com/ziutek/mymysql v1.5.5-0.20171217234033-ff6cc86d3d93 // indirect
+	golang.org/x/net v0.0.0-20180921000356-2f5d2388922f // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8 // indirect
 	google.golang.org/appengine v1.1.0 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/gorilla/securecookie v1.1.2-0.20180608144417-78f3d318a8bf h1:tgJ+TrHb
 github.com/gorilla/securecookie v1.1.2-0.20180608144417-78f3d318a8bf/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.1.1 h1:YMDmfaK68mUixINzY/XjscuJ47uXFWSSHzFbBQM0PrE=
 github.com/gorilla/sessions v1.1.1/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmoiron/sqlx v1.2.1-0.20181024163419-82935fac6c1a h1:7F1aETmIWwSQAv4S2415VrWj9eJyxR3epEEb6O5isgA=
 github.com/jmoiron/sqlx v1.2.1-0.20181024163419-82935fac6c1a/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
@@ -47,7 +48,9 @@ github.com/rubenv/sql-migrate v0.0.0-20180704111356-3f452fc0ebeb h1:lAOy8O8yKU3u
 github.com/rubenv/sql-migrate v0.0.0-20180704111356-3f452fc0ebeb/go.mod h1:WS0rl9eEliYI8DPnr3TOwz4439pay+qNgzJoVya/DmY=
 github.com/sirupsen/logrus v1.0.7-0.20180723115307-c108f5553c36 h1:NvBdWUXstAlJwU7RjOTudVgMj5N/NTYKJxwoJN5+0XY=
 github.com/sirupsen/logrus v1.0.7-0.20180723115307-c108f5553c36/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/pflag v1.0.2 h1:Fy0orTDgHdbnzHcsOgfCN4LtHf0ec3wwtiwJqwvf3Gc=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -57,7 +60,9 @@ github.com/ziutek/mymysql v1.5.5-0.20171217234033-ff6cc86d3d93 h1:neEPpeeJDl7Rs0
 github.com/ziutek/mymysql v1.5.5-0.20171217234033-ff6cc86d3d93/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb h1:Ah9YqXLj6fEgeKqcmBuLCbAsrF3ScD7dJ/bYM0C6tXI=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20180921000356-2f5d2388922f h1:QM2QVxvDoW9PFSPp/zy9FgxJLfaWTZlS61KEPtBwacM=
 golang.org/x/net v0.0.0-20180921000356-2f5d2388922f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8 h1:7T3bTJEttnfJdEY+NY/VYT7IXRaul8potWiyw/n7LB8=
 golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This one fixes the build of the container while trying to touch a bare minimum.
go moved from "go get" to "go install" long ago



```
[kallisti5@eris fathom]$ docker build . -t docker.io/haiku/fathom:93b968
[1/3] STEP 1/6: FROM node:alpine AS assetbuilder
[1/3] STEP 2/6: WORKDIR /app
--> Using cache cabf093f522b2506f21d21d0f516d09e180f398e44be9b86dd18af88d299e792
--> cabf093f522
[1/3] STEP 3/6: COPY package*.json ./
--> Using cache c8575b04631ea97bfe24f458bb1ca82fee5976714a1ec50ddca37475893b31f9
--> c8575b04631
[1/3] STEP 4/6: COPY gulpfile.js ./
--> Using cache c1fa176902a1cca22869b7a0881967332be38ed40482c44c5655f54b8d711f19
--> c1fa176902a
[1/3] STEP 5/6: COPY assets/ ./assets/
--> Using cache da3fa74df099fab5bfddb818757fa4f2c72e4c8b629fc091153c1113a676e1f4
--> da3fa74df09
[1/3] STEP 6/6: RUN npm install && NODE_ENV=production ./node_modules/gulp/bin/gulp.js
--> Using cache cc31475b32503d39f325d2a1eea1415aedd702bb5981f7f3fdae6ddf2911c871
--> cc31475b325
[2/3] STEP 1/6: FROM golang:latest AS binarybuilder
[2/3] STEP 2/6: RUN go install github.com/gobuffalo/packr/packr@latest
--> Using cache bbd4df99b6b096e965d436e9846b6fa406d3b3fad194d06605f47d26c0fcaf9c
--> bbd4df99b6b
[2/3] STEP 3/6: WORKDIR /go/src/github.com/usefathom/fathom
--> Using cache 8a46ce9547bee69ff86c9da54983efff7df78b25757575f9c7ac984b25f65f7a
--> 8a46ce9547b
[2/3] STEP 4/6: COPY . /go/src/github.com/usefathom/fathom
--> 8b6bcc2181b
[2/3] STEP 5/6: COPY --from=assetbuilder /app/assets/build ./assets/build
--> 49167613af7
[2/3] STEP 6/6: RUN make docker
GOOS=linux GOARCH=amd64 /go/bin/packr build -v -ldflags '-w -extldflags "-static" -X "main.version=1.2.1+79-gf7303e8" -X "main.commit=f7303e8197b31849152bc2bf463c57f9028ec67c"  -X "main.date="' -o fathom ./main.go
building box ./../../assets/build
packing file 404.html
packed file 404.html
packing file css/styles.css
packed file css/styles.css
packing file fonts/overpass-bold-italic.eot
building box ./migrations
packing file mysql/10_alter_stats_table_constraints.sql
packed file mysql/10_alter_stats_table_constraints.sql
.
.
packed file js/tracker.js
built box ./../../assets/build with ["404.html" "css/styles.css" "fonts/overpass-bold-italic.eot" "fonts/overpass-bold-italic.ttf" "fonts/overpass-bold-italic.woff" "fonts/overpass-bold-italic.woff2" "fonts/overpass-bold.eot" "fonts/overpass-bold.ttf" "fonts/overpass-bold.woff" "fonts/overpass-bold.woff2" "fonts/overpass-extrabold-italic.eot" "fonts/overpass-extrabold-italic.ttf" "fonts/overpass-extrabold-italic.woff" "fonts/overpass-extrabold-italic.woff2" "fonts/overpass-extrabold.eot" "fonts/overpass-extrabold.ttf" "fonts/overpass-extrabold.woff" "fonts/overpass-extrabold.woff2" "fonts/overpass-extralight-italic.eot" "fonts/overpass-extralight-italic.ttf" "fonts/overpass-extralight-italic.woff" "fonts/overpass-extralight-italic.woff2" "fonts/overpass-extralight.eot" "fonts/overpass-extralight.ttf" "fonts/overpass-extralight.woff" "fonts/overpass-extralight.woff2" "fonts/overpass-heavy-italic.eot" "fonts/overpass-heavy-italic.ttf" "fonts/overpass-heavy-italic.woff" "fonts/overpass-heavy-italic.woff2" "fonts/overpass-heavy.eot" "fonts/overpass-heavy.ttf" "fonts/overpass-heavy.woff" "fonts/overpass-heavy.woff2" "fonts/overpass-italic.eot" "fonts/overpass-italic.ttf" "fonts/overpass-italic.woff" "fonts/overpass-italic.woff2" "fonts/overpass-light-italic.eot" "fonts/overpass-light-italic.ttf" "fonts/overpass-light-italic.woff" "fonts/overpass-light-italic.woff2" "fonts/overpass-light.eot" "fonts/overpass-light.ttf" "fonts/overpass-light.woff" "fonts/overpass-light.woff2" "fonts/overpass-regular.eot" "fonts/overpass-regular.ttf" "fonts/overpass-regular.woff" "fonts/overpass-regular.woff2" "fonts/overpass-semibold-italic.eot" "fonts/overpass-semibold-italic.ttf" "fonts/overpass-semibold-italic.woff" "fonts/overpass-semibold-italic.woff2" "fonts/overpass-semibold.eot" "fonts/overpass-semibold.ttf" "fonts/overpass-semibold.woff" "fonts/overpass-semibold.woff2" "fonts/overpass-thin-italic.eot" "fonts/overpass-thin-italic.ttf" "fonts/overpass-thin-italic.woff" "fonts/overpass-thin-italic.woff2" "fonts/overpass-thin.eot" "fonts/overpass-thin.ttf" "fonts/overpass-thin.woff" "fonts/overpass-thin.woff2" "img/fathom.jpg" "img/favicon.png" "index.html" "js/script.js" "js/tracker.js"]
go: downloading github.com/urfave/cli v1.20.1-0.20180226030253-8e01ec4cd3e2
go: downloading github.com/kelseyhightower/envconfig v1.3.1-0.20180517194557-dd1402a4d99d
go: downloading github.com/gorilla/handlers v1.3.1-0.20180717233320-6257a585e449
go: downloading golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
go: downloading github.com/sirupsen/logrus v1.0.7-0.20180723115307-c108f5553c36
go: downloading github.com/lib/pq v1.10.4
go: downloading github.com/go-sql-driver/mysql v1.4.1-0.20181113023849-369b5d6e5e8e
go: downloading github.com/mattn/go-sqlite3 v1.10.1-0.20181109095304-eed79b86572f
go: downloading github.com/jmoiron/sqlx v1.2.1-0.20181024163419-82935fac6c1a
go: downloading github.com/gobuffalo/packr v1.13.7
go: downloading github.com/gorilla/context v1.1.1
go: downloading github.com/rubenv/sql-migrate v0.0.0-20180704111356-3f452fc0ebeb
go: downloading github.com/gorilla/mux v1.6.3-0.20180605211556-cb4698366aa6
go: downloading github.com/gorilla/sessions v1.1.1
go: downloading github.com/mssola/user_agent v0.4.2-0.20180608081648-d7bd3b07ee86
go: downloading github.com/gorilla/securecookie v1.1.2-0.20180608144417-78f3d318a8bf
go: downloading gopkg.in/gorp.v1 v1.7.1
go: downloading github.com/pkg/errors v0.8.1-0.20180311214515-816c9085562c
go: downloading golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8
github.com/lib/pq/oid
golang.org/x/crypto/blowfish
github.com/jmoiron/sqlx/reflectx
github.com/mssola/user_agent
golang.org/x/sys/unix
github.com/rubenv/sql-migrate/sqlparse
github.com/pkg/errors
gopkg.in/gorp.v1
github.com/kelseyhightower/envconfig
github.com/urfave/cli
github.com/lib/pq/scram
github.com/gorilla/securecookie
github.com/go-sql-driver/mysql
github.com/gorilla/context
golang.org/x/crypto/acme
github.com/gorilla/handlers
github.com/gorilla/mux
golang.org/x/crypto/bcrypt
github.com/mattn/go-sqlite3
github.com/gobuffalo/packr
github.com/jmoiron/sqlx
github.com/lib/pq
github.com/usefathom/fathom/pkg/models
github.com/gorilla/sessions
golang.org/x/crypto/acme/autocert
github.com/rubenv/sql-migrate
golang.org/x/crypto/ssh/terminal
github.com/sirupsen/logrus
# github.com/mattn/go-sqlite3
sqlite3-binding.c: In function 'sqlite3SelectNew':
sqlite3-binding.c:123303:10: warning: function may return address of local variable [-Wreturn-local-addr]
123303 |   return pNew;
       |          ^~~~
sqlite3-binding.c:123263:10: note: declared here
123263 |   Select standin;
       |          ^~~~~~~
github.com/usefathom/fathom/pkg/datastore/sqlstore
github.com/usefathom/fathom/pkg/datastore
github.com/usefathom/fathom/pkg/config
github.com/usefathom/fathom/pkg/aggregator
github.com/usefathom/fathom/pkg/api
github.com/usefathom/fathom/pkg/cli
command-line-arguments
# command-line-arguments
/usr/bin/ld: /tmp/go-link-1506985487/000015.o: in function `unixDlOpen':
/go/pkg/mod/github.com/mattn/go-sqlite3@v1.10.1-0.20181109095304-eed79b86572f/sqlite3-binding.c:38461: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1506985487/000033.o: in function `mygetgrouplist':
/_/os/user/getgrouplist_unix.go:15: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1506985487/000032.o: in function `mygetgrgid_r':
/_/os/user/cgo_lookup_unix.go:37: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1506985487/000032.o: in function `mygetgrnam_r':
/_/os/user/cgo_lookup_unix.go:42: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1506985487/000032.o: in function `mygetpwnam_r':
/_/os/user/cgo_lookup_unix.go:32: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1506985487/000032.o: in function `mygetpwuid_r':
/_/os/user/cgo_lookup_unix.go:27: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1506985487/000004.o: in function `_cgo_6cc2654a8ed3_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
--> 03805521aa7
[3/3] STEP 1/7: FROM alpine:latest
[3/3] STEP 2/7: EXPOSE 8080
--> Using cache 6d6fdd629e9c7273bbe645ec624615f147ad44ce8c4597660e75c8331887f400
--> 6d6fdd629e9
[3/3] STEP 3/7: HEALTHCHECK --retries=10 CMD ["wget", "-qO-", "http://localhost:8080/health"]
--> Using cache 7325ec941f9dcbbe0727014d470eae7715d3c7fe081926c190a6a0d29e3ba949
--> 7325ec941f9
[3/3] STEP 4/7: RUN apk add --update --no-cache bash ca-certificates
--> Using cache fdc8c7480c08b10b165e53651fe4780fc21f257852dca3ca1310b765827c2ed5
--> fdc8c7480c0
[3/3] STEP 5/7: WORKDIR /app
--> Using cache 233b6ec71d0c24b65f1caaa0d948ecbba82a0a9f0fb0f89cbd23fd914b7e3ba5
--> 233b6ec71d0
[3/3] STEP 6/7: COPY --from=binarybuilder /go/src/github.com/usefathom/fathom/fathom .
WARN[0049] HEALTHCHECK is not supported for OCI image format and will be ignored. Must use `docker` format 
--> 7594198b032
[3/3] STEP 7/7: CMD ["./fathom", "server"]
[3/3] COMMIT docker.io/haiku/fathom:93b968
WARN[0049] HEALTHCHECK is not supported for OCI image format and will be ignored. Must use `docker` format 
--> 563ac59dfb1
Successfully tagged docker.io/haiku/fathom:93b968
563ac59dfb12a7a4b8e1b13d56b87e359ed1f219cbc51225ab638b667b50a31a
```